### PR TITLE
Fix #7

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ impl<K: Eq + Hash + Clone, V> SieveCache<K, V> {
         self.nodes.push(node);
         let idx = self.nodes.len() - 1;
         self.map.insert(key, idx);
-        debug_assert!(self.nodes.len() < self.capacity);
+        debug_assert!(self.nodes.len() <= self.capacity);
         true
     }
 


### PR DESCRIPTION
<= is the right check - < is too strict, and that 'strictness' is only required when done inside the 'if self.nodes.len() >= self.capacity {' block above, to confirm evict() did evict an item.
The line was moved around, but I failed to git add the fixed condition.