### PR TITLE
feat: add option for using custom hashers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,47 +105,51 @@ These implementations are available when using the appropriate feature flags:
 For concurrent access from multiple threads, you can use the `SyncSieveCache` wrapper, which provides thread safety with a single global lock:
 
 ```rust
-use sieve_cache::SyncSieveCache;
-use std::thread;
-
-// Create a thread-safe cache
-let cache = SyncSieveCache::new(100000).unwrap();
-
-// The cache can be safely cloned and shared between threads
-let cache_clone = cache.clone();
-
-// Insert from the main thread
-cache.insert("foo".to_string(), "foocontent".to_string());
-
-// Access from another thread
-let handle = thread::spawn(move || {
-    // Insert a new key
-    cache_clone.insert("bar".to_string(), "barcontent".to_string());
-
-    // Get returns a clone of the value, not a reference (unlike non-thread-safe version)
-    assert_eq!(cache_clone.get(&"foo".to_string()), Some("foocontent".to_string()));
-});
-
-// Wait for the thread to complete
-handle.join().unwrap();
-
-// Check if keys exist
-assert!(cache.contains_key(&"foo".to_string()));
-assert!(cache.contains_key(&"bar".to_string()));
-
-// Remove an entry
-let removed = cache.remove(&"bar".to_string());
-assert_eq!(removed, Some("barcontent".to_string()));
-
-// Perform multiple operations atomically with exclusive access
-cache.with_lock(|inner_cache| {
-    // Operations inside this closure have exclusive access to the cache
-    inner_cache.insert("atomic1".to_string(), "value1".to_string());
-    inner_cache.insert("atomic2".to_string(), "value2".to_string());
-
-    // We can check internal state as part of the transaction
-    assert_eq!(inner_cache.len(), 3);
-});
+// the line below is required for doctests, you will rarely need to wrap code like this.
+# #[cfg(feature = "sync")]
+{
+    use sieve_cache::SyncSieveCache;
+    use std::thread;
+    
+    // Create a thread-safe cache
+    let cache = SyncSieveCache::new(100000).unwrap();
+    
+    // The cache can be safely cloned and shared between threads
+    let cache_clone = cache.clone();
+    
+    // Insert from the main thread
+    cache.insert("foo".to_string(), "foocontent".to_string());
+    
+    // Access from another thread
+    let handle = thread::spawn(move || {
+        // Insert a new key
+        cache_clone.insert("bar".to_string(), "barcontent".to_string());
+    
+        // Get returns a clone of the value, not a reference (unlike non-thread-safe version)
+        assert_eq!(cache_clone.get(&"foo".to_string()), Some("foocontent".to_string()));
+    });
+    
+    // Wait for the thread to complete
+    handle.join().unwrap();
+    
+    // Check if keys exist
+    assert!(cache.contains_key(&"foo".to_string()));
+    assert!(cache.contains_key(&"bar".to_string()));
+    
+    // Remove an entry
+    let removed = cache.remove(&"bar".to_string());
+    assert_eq!(removed, Some("barcontent".to_string()));
+    
+    // Perform multiple operations atomically with exclusive access
+    cache.with_lock(|inner_cache| {
+        // Operations inside this closure have exclusive access to the cache
+        inner_cache.insert("atomic1".to_string(), "value1".to_string());
+        inner_cache.insert("atomic2".to_string(), "value2".to_string());
+    
+        // We can check internal state as part of the transaction
+        assert_eq!(inner_cache.len(), 3);
+    });
+}
 ```
 
 Key differences from the non-thread-safe version:
@@ -158,59 +162,63 @@ Key differences from the non-thread-safe version:
 For applications with high concurrency requirements, the `ShardedSieveCache` implementation uses multiple internal locks (sharding) to reduce contention and improve throughput:
 
 ```rust
-use sieve_cache::ShardedSieveCache;
-use std::thread;
-use std::sync::Arc;
-
-// Create a sharded cache with default shard count (16)
-// We use Arc for sharing between threads
-let cache = Arc::new(ShardedSieveCache::new(100000).unwrap());
-
-// Alternatively, specify a custom number of shards
-// let cache = Arc::new(ShardedSieveCache::with_shards(100000, 32).unwrap());
-
-// Insert data from the main thread
-cache.insert("foo".to_string(), "foocontent".to_string());
-
-// Use multiple worker threads to insert data concurrently
-let mut handles = vec![];
-for i in 0..8 {
-    let cache_clone = Arc::clone(&cache);
-    let handle = thread::spawn(move || {
-        // Each thread inserts multiple values
-        for j in 0..100 {
-            let key = format!("key_thread{}_item{}", i, j);
-            let value = format!("value_{}", j);
-            cache_clone.insert(key, value);
-        }
+// the line below is required for doctests, you will rarely need to wrap code like this.
+# #[cfg(feature = "sharded")]
+{
+    use sieve_cache::ShardedSieveCache;
+    use std::thread;
+    use std::sync::Arc;
+    
+    // Create a sharded cache with default shard count (16)
+    // We use Arc for sharing between threads
+    let cache = Arc::new(ShardedSieveCache::new(100000).unwrap());
+    
+    // Alternatively, specify a custom number of shards
+    // let cache = Arc::new(ShardedSieveCache::with_shards(100000, 32).unwrap());
+    
+    // Insert data from the main thread
+    cache.insert("foo".to_string(), "foocontent".to_string());
+    
+    // Use multiple worker threads to insert data concurrently
+    let mut handles = vec![];
+    for i in 0..8 {
+        let cache_clone = Arc::clone(&cache);
+        let handle = thread::spawn(move || {
+            // Each thread inserts multiple values
+            for j in 0..100 {
+                let key = format!("key_thread{}_item{}", i, j);
+                let value = format!("value_{}", j);
+                cache_clone.insert(key, value);
+            }
+        });
+        handles.push(handle);
+    }
+    
+    // Wait for all threads to complete
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    
+    // Shard-specific atomic operations
+    // with_key_lock locks only the shard containing the key
+    cache.with_key_lock(&"foo", |shard| {
+        // Operations inside this closure have exclusive access to the specific shard
+        shard.insert("related_key1".to_string(), "value1".to_string());
+        shard.insert("related_key2".to_string(), "value2".to_string());
+    
+        // We can check internal state within the transaction
+        assert!(shard.contains_key(&"related_key1".to_string()));
     });
-    handles.push(handle);
+    
+    // Get the number of entries across all shards
+    // Note: This acquires all shard locks sequentially
+    let total_entries = cache.len();
+    assert_eq!(total_entries, 803); // 800 from threads + 1 "foo" + 2 related keys
+    
+    // Access shard information
+    println!("Cache has {} shards with total capacity {}",
+             cache.num_shards(), cache.capacity());
 }
-
-// Wait for all threads to complete
-for handle in handles {
-    handle.join().unwrap();
-}
-
-// Shard-specific atomic operations
-// with_key_lock locks only the shard containing the key
-cache.with_key_lock(&"foo", |shard| {
-    // Operations inside this closure have exclusive access to the specific shard
-    shard.insert("related_key1".to_string(), "value1".to_string());
-    shard.insert("related_key2".to_string(), "value2".to_string());
-
-    // We can check internal state within the transaction
-    assert!(shard.contains_key(&"related_key1".to_string()));
-});
-
-// Get the number of entries across all shards
-// Note: This acquires all shard locks sequentially
-let total_entries = cache.len();
-assert_eq!(total_entries, 803); // 800 from threads + 1 "foo" + 2 related keys
-
-// Access shard information
-println!("Cache has {} shards with total capacity {}",
-         cache.num_shards(), cache.capacity());
 ```
 
 #### How Sharding Works
@@ -230,24 +238,28 @@ The `weighted` feature (enabled by default) adds cache implementations that evic
 ### `WeightedSieveCache` - Single-Threaded
 
 ```rust
-use sieve_cache::{Weigh, WeightedSieveCache};
-
-// Create a cache that holds at most 10 entries and 1 KB of weight
-let mut cache = WeightedSieveCache::new(10, 1024).unwrap();
-
-cache.insert("key".to_string(), "value".to_string());
-assert!(cache.current_weight() > 0);
-assert!(cache.current_weight() <= cache.max_weight());
-
-// Weight is snapshotted at insert time.
-// Mutating via get_mut does not change the tracked weight.
-if let Some(v) = cache.get_mut("key") {
-    *v = "a much longer string".to_string();
+// the line below is required for doctests, you will rarely need to wrap code like this.
+# #[cfg(feature = "weighted")]
+{
+    use sieve_cache::{Weigh, WeightedSieveCache};
+    
+    // Create a cache that holds at most 10 entries and 1 KB of weight
+    let mut cache = WeightedSieveCache::new(10, 1024).unwrap();
+    
+    cache.insert("key".to_string(), "value".to_string());
+    assert!(cache.current_weight() > 0);
+    assert!(cache.current_weight() <= cache.max_weight());
+    
+    // Weight is snapshotted at insert time.
+    // Mutating via get_mut does not change the tracked weight.
+    if let Some(v) = cache.get_mut("key") {
+        *v = "a much longer string".to_string();
+    }
+    // current_weight still reflects the original "value"
+    
+    // Entries are evicted automatically when inserting would exceed max_weight.
+    // A single oversized entry is allowed as the sole occupant.
 }
-// current_weight still reflects the original "value"
-
-// Entries are evicted automatically when inserting would exceed max_weight.
-// A single oversized entry is allowed as the sole occupant.
 ```
 
 Thread-safe variants follow the same pattern as their non-weighted counterparts:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ let recommended = cache.recommended_capacity(0.5, 2.0, 0.3, 0.7);
 println!("Recommended capacity: {}", recommended);
 ```
 
+### Custom Hash Builder
+
+You can also specify a custom hash builder to use a different hashing algorithm (e.g., `ahash` for faster hashing):
+
+```rust
+use sieve_cache::SieveCache;
+use std::hash::BuildHasherDefault;
+use std::collections::hash_map::DefaultHasher;
+
+// Create a cache with a custom hash builder
+let hasher = BuildHasherDefault::<DefaultHasher>::default();
+let mut cache: SieveCache<String, String, _> = SieveCache::new_with_hasher(100000, hasher).unwrap();
+
+// Use the cache normally
+cache.insert("key".to_string(), "value".to_string());
+assert_eq!(cache.get("key"), Some(&"value".to_string()));
+```
+
+This feature is useful when you need to optimize hashing performance for specific workloads or integrate with crates like `ahash`.
+
 ## Thread-Safe Implementations
 
 These implementations are available when using the appropriate feature flags:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1394,3 +1394,32 @@ fn insert_never_exceeds_capacity_when_all_visited() {
     // This is our an invariant
     assert!(c.len() <= c.capacity());
 }
+
+#[test]
+fn test_custom_hasher_sievecache() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::BuildHasherDefault;
+
+    let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    let mut cache: SieveCache<String, String, _> =
+        SieveCache::new_with_hasher(10, hasher).unwrap();
+
+    // Test basic insert and get operations with custom hasher
+    assert!(cache.insert("key1".to_string(), "value1".to_string()));
+    assert!(cache.insert("key2".to_string(), "value2".to_string()));
+    assert!(cache.insert("key3".to_string(), "value3".to_string()));
+
+    // Verify values are retrievable
+    assert_eq!(cache.get("key1"), Some(&"value1".to_string()));
+    assert_eq!(cache.get("key2"), Some(&"value2".to_string()));
+    assert_eq!(cache.get("key3"), Some(&"value3".to_string()));
+
+    // Test remove with custom hasher
+    assert_eq!(cache.remove("key1"), Some("value1".to_string()));
+    assert_eq!(cache.get("key1"), None);
+    assert_eq!(cache.len(), 2);
+
+    // Test contains_key
+    assert!(cache.contains_key("key2"));
+    assert!(!cache.contains_key("key1"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,9 @@ pub mod _docs_sharded_usage {
     //!   are distributed across many different keys
 }
 
-use std::{borrow::Borrow, hash::BuildHasher};
 use std::collections::HashMap;
 use std::hash::{Hash, RandomState};
+use std::{borrow::Borrow, hash::BuildHasher};
 
 #[cfg(feature = "sharded")]
 mod sharded;
@@ -1401,8 +1401,7 @@ fn test_custom_hasher_sievecache() {
     use std::hash::BuildHasherDefault;
 
     let hasher = BuildHasherDefault::<DefaultHasher>::default();
-    let mut cache: SieveCache<String, String, _> =
-        SieveCache::new_with_hasher(10, hasher).unwrap();
+    let mut cache: SieveCache<String, String, _> = SieveCache::new_with_hasher(10, hasher).unwrap();
 
     // Test basic insert and get operations with custom hasher
     assert!(cache.insert("key1".to_string(), "value1".to_string()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,9 @@ pub mod _docs_sharded_usage {
     //!   are distributed across many different keys
 }
 
-use std::borrow::Borrow;
+use std::{borrow::Borrow, hash::BuildHasher};
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{Hash, RandomState};
 
 #[cfg(feature = "sharded")]
 mod sharded;
@@ -136,6 +136,7 @@ impl<K: Eq + Hash + Clone, V> Node<K, V> {
 ///
 /// * `K` - The key type, which must implement `Eq`, `Hash`, and `Clone`
 /// * `V` - The value type, with no constraints
+/// * `S` - The hash builder type for the underlying `HashMap` (default: `RandomState`). Must implement `BuildHasher`
 ///
 /// # Example
 ///
@@ -171,9 +172,9 @@ impl<K: Eq + Hash + Clone, V> Node<K, V> {
 /// assert_eq!(removed, Some("value2".to_string()));
 /// # }
 /// ```
-pub struct SieveCache<K: Eq + Hash + Clone, V> {
+pub struct SieveCache<K: Eq + Hash + Clone, V, S: BuildHasher = RandomState> {
     /// Map of keys to indices in the nodes vector
-    map: HashMap<K, usize>,
+    map: HashMap<K, usize, S>,
     /// Vector of all cache nodes
     nodes: Vec<Node<K, V>>,
     /// Index to the "hand" pointer used by the SIEVE algorithm for eviction
@@ -209,11 +210,47 @@ impl<K: Eq + Hash + Clone, V> SieveCache<K, V> {
     /// # }
     /// ```
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
+        Self::new_with_hasher(capacity, Default::default())
+    }
+}
+
+impl<K: Eq + Hash + Clone, V, S: BuildHasher> SieveCache<K, V, S> {
+    /// Creates a new cache with the given capacity using a custom hash builder.
+    ///
+    /// The capacity represents the maximum number of key-value pairs
+    /// that can be stored in the cache. When this limit is reached,
+    /// the cache will use the SIEVE algorithm to evict entries.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The maximum number of entries in the cache
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the capacity is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "doctest")]
+    /// # {
+    /// use sieve_cache::SieveCache;
+    /// use std::hash::BuildHasherDefault;
+    /// use std::collections::hash_map::DefaultHasher;
+    ///
+    /// // Create a cache with a custom hasher
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: SieveCache<String, u32, _> = SieveCache::new_with_hasher(100, hasher).unwrap();
+    /// assert_eq!(cache.capacity(), 100);
+    /// # }
+    /// ```
+    pub fn new_with_hasher(capacity: usize, hasher: S) -> Result<Self, &'static str> {
         if capacity == 0 {
             return Err("capacity must be greater than 0");
         }
         Ok(Self {
-            map: HashMap::with_capacity(capacity),
+            map: HashMap::with_capacity_and_hasher(capacity, hasher),
             nodes: Vec::with_capacity(capacity),
             hand: None,
             capacity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,36 @@ impl<K: Eq + Hash + Clone, V, S: BuildHasher> SieveCache<K, V, S> {
             capacity,
         })
     }
+}
 
+// hasher() can only be implemented if the BuildHasher is also Clone,
+// since copies of mere references will be dropped by the MutexGuard in shared variants.
+impl<K: Eq + Hash + Clone, V, S: BuildHasher + Clone> SieveCache<K, V, S> {
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to a sharded or thread-safe variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "doctest")]
+    /// # {
+    /// use sieve_cache::SieveCache;
+    /// use std::hash::BuildHasherDefault;
+    /// use std::collections::hash_map::DefaultHasher;
+    ///
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: SieveCache<String, u32, _> = SieveCache::new_with_hasher(100, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// # }
+    /// ```
+    pub fn hasher(&self) -> S {
+        (self.map.hasher()).clone()
+    }
+}
+
+impl<K: Eq + Hash + Clone, V, S: BuildHasher> SieveCache<K, V, S> {
     /// Returns the capacity of the cache.
     ///
     /// This is the maximum number of entries that can be stored before

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -125,20 +125,20 @@ pub struct ShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     /// Array of shard mutexes, each containing a separate SieveCache instance
     shards: Vec<Arc<Mutex<SieveCache<K, V, S>>>>,
     /// Number of shards in the cache - kept as a separate field for quick access
     num_shards: usize,
-    hasher: S
+    hasher: S,
 }
 
 impl<K, V, S> Default for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher + Clone + Default
+    S: BuildHasher + Clone + Default,
 {
     /// Creates a new sharded cache with a default capacity of 100 entries and default number of shards.
     ///
@@ -157,7 +157,8 @@ where
     /// assert_eq!(cache.num_shards(), 16); // Default shard count
     /// ```
     fn default() -> Self {
-        Self::new_with_hasher(100, Default::default()).expect("Failed to create cache with default capacity")
+        Self::new_with_hasher(100, Default::default())
+            .expect("Failed to create cache with default capacity")
     }
 }
 
@@ -165,7 +166,7 @@ impl<K, V, S> fmt::Debug for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync + fmt::Debug,
     V: Send + Sync + fmt::Debug,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ShardedSieveCache")
@@ -180,7 +181,7 @@ impl<K, V, S> IntoIterator for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     type Item = (K, V);
     type IntoIter = std::vec::IntoIter<(K, V)>;
@@ -213,7 +214,7 @@ impl<K, V, S> From<crate::SyncSieveCache<K, V, S>> for ShardedSieveCache<K, V, S
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
-    S: BuildHasher + Clone + Default
+    S: BuildHasher + Clone + Default,
 {
     /// Creates a new sharded cache from an existing `SyncSieveCache`.
     ///
@@ -233,7 +234,8 @@ where
     fn from(sync_cache: crate::SyncSieveCache<K, V, S>) -> Self {
         // Create a new sharded cache with the same capacity
         let capacity = sync_cache.capacity();
-        let sharded = Self::new_with_hasher(capacity, Default::default()).expect("Failed to create sharded cache");
+        let sharded = Self::new_with_hasher(capacity, Default::default())
+            .expect("Failed to create sharded cache");
 
         // Transfer all entries
         for (key, value) in sync_cache.entries() {
@@ -268,7 +270,7 @@ where
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
         Self::with_shards(capacity, DEFAULT_SHARDS)
     }
-    
+
     /// Creates a new sharded cache with the specified capacity and number of shards.
     ///
     /// The capacity will be divided among the shards, distributing any remainder to ensure
@@ -308,7 +310,7 @@ impl<K, V, S> ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     /// Creates a new sharded cache with the specified capacity using a custom hash builder and default number of shards.
     ///
@@ -337,7 +339,7 @@ where
     pub fn new_with_hasher(capacity: usize, hasher: S) -> Result<Self, &'static str> {
         Self::with_shards_and_hasher(capacity, DEFAULT_SHARDS, hasher)
     }
- 
+
     /// Creates a new sharded cache with the specified capacity, number of shards, and custom hash builder.
     ///
     /// The capacity will be divided among the shards, distributing any remainder to ensure
@@ -372,7 +374,11 @@ where
     /// assert_eq!(cache.num_shards(), 8);
     /// assert!(cache.capacity() >= 1000);
     /// ```
-    pub fn with_shards_and_hasher(capacity: usize, num_shards: usize, hasher: S) -> Result<Self, &'static str> {
+    pub fn with_shards_and_hasher(
+        capacity: usize,
+        num_shards: usize,
+        hasher: S,
+    ) -> Result<Self, &'static str> {
         if capacity == 0 {
             return Err("capacity must be greater than 0");
         }
@@ -395,10 +401,17 @@ where
 
             // Ensure at least capacity 1 per shard
             let shard_capacity = std::cmp::max(1, shard_capacity);
-            shards.push(Arc::new(Mutex::new(SieveCache::new_with_hasher(shard_capacity, hasher.clone())?)));
+            shards.push(Arc::new(Mutex::new(SieveCache::new_with_hasher(
+                shard_capacity,
+                hasher.clone(),
+            )?)));
         }
 
-        Ok(Self { shards, num_shards, hasher })
+        Ok(Self {
+            shards,
+            num_shards,
+            hasher,
+        })
     }
 
     /// Returns the shard index for a given key.
@@ -1786,9 +1799,10 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::BuildHasherDefault;
 
-        // Test with custom hasher and default shard count  
+        // Test with custom hasher and default shard count
         let cache: ShardedSieveCache<String, i32, _> =
-            ShardedSieveCache::new_with_hasher(10, BuildHasherDefault::<DefaultHasher>::new()).unwrap();
+            ShardedSieveCache::new_with_hasher(10, BuildHasherDefault::<DefaultHasher>::new())
+                .unwrap();
 
         // Test basic insert operations
         assert!(cache.insert("a".to_string(), 1));
@@ -1800,10 +1814,10 @@ mod tests {
         assert_eq!(cache.get(&"b".to_string()), Some(2));
         assert_eq!(cache.get(&"c".to_string()), Some(3));
 
-        // Test remove 
+        // Test remove
         assert_eq!(cache.remove(&"a".to_string()), Some(1));
         assert_eq!(cache.get(&"a".to_string()), None);
-        
+
         // Test contains
         assert!(cache.contains_key(&"b".to_string()));
         assert!(!cache.contains_key(&"a".to_string()));
@@ -1831,7 +1845,10 @@ mod tests {
         assert_eq!(cache.get(&"key4".to_string()), Some("value4".to_string()));
 
         // Test remove and contains_key
-        assert_eq!(cache.remove(&"key2".to_string()), Some("value2".to_string()));
+        assert_eq!(
+            cache.remove(&"key2".to_string()),
+            Some("value2".to_string())
+        );
         assert!(!cache.contains_key(&"key2".to_string()));
         assert_eq!(cache.len(), 3);
     }

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -12,7 +12,7 @@ const DEFAULT_SHARDS: usize = 16;
 /// A thread-safe implementation of `SieveCache` that uses multiple shards to reduce contention.
 ///
 /// This provides better concurrency than `SyncSieveCache` by splitting the cache into multiple
-/// independent shards, each protected by its own mutex. Operations on different shards can
+/// independent shards, each priotected by its own mutex. Operations on different shards can
 /// proceed in parallel, which can significantly improve throughput in multi-threaded environments.
 ///
 /// # How Sharding Works
@@ -1779,5 +1779,60 @@ mod tests {
         assert_eq!(cache.get(&"keyA_1".to_string()), Some(11)); // 1 + 10
         assert_eq!(cache.get(&"keyB_2".to_string()), Some(22)); // 2 + 20
         assert_eq!(cache.get(&"keyC_3".to_string()), Some(3));
+    }
+
+    #[test]
+    fn test_custom_hasher_sharded_sievecache() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        // Test with custom hasher and default shard count  
+        let cache: ShardedSieveCache<String, i32, _> =
+            ShardedSieveCache::new_with_hasher(10, BuildHasherDefault::<DefaultHasher>::new()).unwrap();
+
+        // Test basic insert operations
+        assert!(cache.insert("a".to_string(), 1));
+        assert!(cache.insert("b".to_string(), 2));
+        assert!(cache.insert("c".to_string(), 3));
+
+        // Verify values can be retrieved
+        assert_eq!(cache.get(&"a".to_string()), Some(1));
+        assert_eq!(cache.get(&"b".to_string()), Some(2));
+        assert_eq!(cache.get(&"c".to_string()), Some(3));
+
+        // Test remove 
+        assert_eq!(cache.remove(&"a".to_string()), Some(1));
+        assert_eq!(cache.get(&"a".to_string()), None);
+        
+        // Test contains
+        assert!(cache.contains_key(&"b".to_string()));
+        assert!(!cache.contains_key(&"a".to_string()));
+    }
+
+    #[test]
+    fn test_custom_hasher_sharded_sievecache_with_shards() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let hasher = BuildHasherDefault::<DefaultHasher>::default();
+        let cache: ShardedSieveCache<String, String, _> =
+            ShardedSieveCache::with_shards_and_hasher(10, 4, hasher).unwrap();
+
+        // Test insert and get with custom hasher and custom shard count
+        assert!(cache.insert("key1".to_string(), "value1".to_string()));
+        assert!(cache.insert("key2".to_string(), "value2".to_string()));
+        assert!(cache.insert("key3".to_string(), "value3".to_string()));
+        assert!(cache.insert("key4".to_string(), "value4".to_string()));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get(&"key1".to_string()), Some("value1".to_string()));
+        assert_eq!(cache.get(&"key2".to_string()), Some("value2".to_string()));
+        assert_eq!(cache.get(&"key3".to_string()), Some("value3".to_string()));
+        assert_eq!(cache.get(&"key4".to_string()), Some("value4".to_string()));
+
+        // Test remove and contains_key
+        assert_eq!(cache.remove(&"key2".to_string()), Some("value2".to_string()));
+        assert!(!cache.contains_key(&"key2".to_string()));
+        assert_eq!(cache.len(), 3);
     }
 }

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -2,7 +2,7 @@ use crate::SieveCache;
 use std::borrow::Borrow;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 /// Default number of shards to use if not specified explicitly.
@@ -69,6 +69,12 @@ const DEFAULT_SHARDS: usize = 16;
 ///   sharding may be limited
 /// - Default of 16 shards provides a good balance for most workloads, but can be customized
 ///
+/// # Type Parameters
+///
+/// * `K` - The key type, which must implement `Eq`, `Hash`, and `Clone` + `Send` + `Sync`
+/// * `V` - The value type, must implement `Send` + `Sync`
+/// * `S` - The hash builder type for the underlying `HashMap` (default: `RandomState`). Must implement `BuildHasher`
+///
 /// # Examples
 ///
 /// ```
@@ -116,21 +122,23 @@ const DEFAULT_SHARDS: usize = 16;
 /// assert_eq!(cache.len(), 400); // All 400 items were inserted
 /// ```
 #[derive(Clone)]
-pub struct ShardedSieveCache<K, V>
+pub struct ShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
+    S: BuildHasher
 {
     /// Array of shard mutexes, each containing a separate SieveCache instance
-    shards: Vec<Arc<Mutex<SieveCache<K, V>>>>,
+    shards: Vec<Arc<Mutex<SieveCache<K, V, S>>>>,
     /// Number of shards in the cache - kept as a separate field for quick access
     num_shards: usize,
 }
 
-impl<K, V> Default for ShardedSieveCache<K, V>
+impl<K, V, S> Default for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
+    S: BuildHasher + Clone + Default
 {
     /// Creates a new sharded cache with a default capacity of 100 entries and default number of shards.
     ///
@@ -149,14 +157,15 @@ where
     /// assert_eq!(cache.num_shards(), 16); // Default shard count
     /// ```
     fn default() -> Self {
-        Self::new(100).expect("Failed to create cache with default capacity")
+        Self::new_with_hasher(100, Default::default()).expect("Failed to create cache with default capacity")
     }
 }
 
-impl<K, V> fmt::Debug for ShardedSieveCache<K, V>
+impl<K, V, S> fmt::Debug for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync + fmt::Debug,
     V: Send + Sync + fmt::Debug,
+    S: BuildHasher + Clone
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ShardedSieveCache")
@@ -167,10 +176,11 @@ where
     }
 }
 
-impl<K, V> IntoIterator for ShardedSieveCache<K, V>
+impl<K, V, S> IntoIterator for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
+    S: BuildHasher + Clone
 {
     type Item = (K, V);
     type IntoIter = std::vec::IntoIter<(K, V)>;
@@ -199,10 +209,11 @@ where
 }
 
 #[cfg(feature = "sync")]
-impl<K, V> From<crate::SyncSieveCache<K, V>> for ShardedSieveCache<K, V>
+impl<K, V, S> From<crate::SyncSieveCache<K, V, S>> for ShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
+    S: BuildHasher + Clone + Default
 {
     /// Creates a new sharded cache from an existing `SyncSieveCache`.
     ///
@@ -219,10 +230,10 @@ where
     /// let sharded_cache = ShardedSieveCache::from(sync_cache);
     /// assert_eq!(sharded_cache.get(&"key".to_string()), Some("value".to_string()));
     /// ```
-    fn from(sync_cache: crate::SyncSieveCache<K, V>) -> Self {
+    fn from(sync_cache: crate::SyncSieveCache<K, V, S>) -> Self {
         // Create a new sharded cache with the same capacity
         let capacity = sync_cache.capacity();
-        let sharded = Self::new(capacity).expect("Failed to create sharded cache");
+        let sharded = Self::new_with_hasher(capacity, Default::default()).expect("Failed to create sharded cache");
 
         // Transfer all entries
         for (key, value) in sync_cache.entries() {
@@ -257,7 +268,7 @@ where
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
         Self::with_shards(capacity, DEFAULT_SHARDS)
     }
-
+    
     /// Creates a new sharded cache with the specified capacity and number of shards.
     ///
     /// The capacity will be divided among the shards, distributing any remainder to ensure
@@ -289,6 +300,79 @@ where
     /// assert!(cache.capacity() >= 1000);
     /// ```
     pub fn with_shards(capacity: usize, num_shards: usize) -> Result<Self, &'static str> {
+        Self::with_shards_and_hasher(capacity, num_shards, Default::default())
+    }
+}
+
+impl<K, V, S> ShardedSieveCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+    V: Send + Sync,
+    S: BuildHasher + Clone
+{
+    /// Creates a new sharded cache with the specified capacity using a custom hash builder and default number of shards.
+    ///
+    /// The capacity will be divided evenly among the shards. The default shard count (16)
+    /// provides a good balance between concurrency and memory overhead for most workloads.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The total capacity of the cache
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the capacity is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::ShardedSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: ShardedSieveCache<String, String, _> = ShardedSieveCache::new_with_hasher(1000, hasher).unwrap();
+    /// assert_eq!(cache.num_shards(), 16); // Default shard count
+    /// ```
+    pub fn new_with_hasher(capacity: usize, hasher: S) -> Result<Self, &'static str> {
+        Self::with_shards_and_hasher(capacity, DEFAULT_SHARDS, hasher)
+    }
+ 
+    /// Creates a new sharded cache with the specified capacity, number of shards, and custom hash builder.
+    ///
+    /// The capacity will be divided among the shards, distributing any remainder to ensure
+    /// the total capacity is at least the requested amount.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The total capacity of the cache
+    /// * `num_shards` - The number of shards to divide the cache into
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either the capacity or number of shards is zero.
+    ///
+    /// # Performance Impact
+    ///
+    /// - More shards can reduce contention in highly concurrent environments
+    /// - However, each shard has memory overhead, so very high shard counts may
+    ///   increase memory usage without providing additional performance benefits
+    /// - For most workloads, a value between 8 and 32 shards is optimal
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::ShardedSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// // Create a cache with 8 shards and a custom hasher
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: ShardedSieveCache<String, u32, _> = ShardedSieveCache::with_shards_and_hasher(1000, 8, hasher).unwrap();
+    /// assert_eq!(cache.num_shards(), 8);
+    /// assert!(cache.capacity() >= 1000);
+    /// ```
+    pub fn with_shards_and_hasher(capacity: usize, num_shards: usize, hasher: S) -> Result<Self, &'static str> {
         if capacity == 0 {
             return Err("capacity must be greater than 0");
         }
@@ -311,7 +395,7 @@ where
 
             // Ensure at least capacity 1 per shard
             let shard_capacity = std::cmp::max(1, shard_capacity);
-            shards.push(Arc::new(Mutex::new(SieveCache::new(shard_capacity)?)));
+            shards.push(Arc::new(Mutex::new(SieveCache::new_with_hasher(shard_capacity, hasher.clone())?)));
         }
 
         Ok(Self { shards, num_shards })
@@ -336,7 +420,7 @@ where
     ///
     /// This is an internal helper method that maps a key to its corresponding shard.
     #[inline]
-    fn get_shard<Q>(&self, key: &Q) -> &Arc<Mutex<SieveCache<K, V>>>
+    fn get_shard<Q>(&self, key: &Q) -> &Arc<Mutex<SieveCache<K, V, S>>>
     where
         Q: Hash + ?Sized,
     {
@@ -350,7 +434,7 @@ where
     /// If the mutex is poisoned due to a panic in another thread, the poison error is
     /// recovered from by calling `into_inner()` to access the underlying data.
     #[inline]
-    fn locked_shard<Q>(&self, key: &Q) -> MutexGuard<'_, SieveCache<K, V>>
+    fn locked_shard<Q>(&self, key: &Q) -> MutexGuard<'_, SieveCache<K, V, S>>
     where
         Q: Hash + ?Sized,
     {
@@ -946,7 +1030,7 @@ where
     pub fn with_key_lock<Q, F, T>(&self, key: &Q, f: F) -> T
     where
         Q: Hash + ?Sized,
-        F: FnOnce(&mut SieveCache<K, V>) -> T,
+        F: FnOnce(&mut SieveCache<K, V, S>) -> T,
     {
         let mut guard = self.locked_shard(key);
         f(&mut guard)
@@ -982,7 +1066,7 @@ where
     /// // Out of bounds index
     /// assert!(cache.get_shard_by_index(100).is_none());
     /// ```
-    pub fn get_shard_by_index(&self, index: usize) -> Option<&Arc<Mutex<SieveCache<K, V>>>> {
+    pub fn get_shard_by_index(&self, index: usize) -> Option<&Arc<Mutex<SieveCache<K, V, S>>>> {
         self.shards.get(index)
     }
 

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -1,6 +1,5 @@
 use crate::SieveCache;
 use std::borrow::Borrow;
-use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -126,12 +125,13 @@ pub struct ShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher
+    S: BuildHasher + Clone
 {
     /// Array of shard mutexes, each containing a separate SieveCache instance
     shards: Vec<Arc<Mutex<SieveCache<K, V, S>>>>,
     /// Number of shards in the cache - kept as a separate field for quick access
     num_shards: usize,
+    hasher: S
 }
 
 impl<K, V, S> Default for ShardedSieveCache<K, V, S>
@@ -398,7 +398,7 @@ where
             shards.push(Arc::new(Mutex::new(SieveCache::new_with_hasher(shard_capacity, hasher.clone())?)));
         }
 
-        Ok(Self { shards, num_shards })
+        Ok(Self { shards, num_shards, hasher })
     }
 
     /// Returns the shard index for a given key.
@@ -410,7 +410,7 @@ where
     where
         Q: Hash + ?Sized,
     {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = self.hasher.build_hasher();
         key.hash(&mut hasher);
         let hash = hasher.finish() as usize;
         hash % self.num_shards

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -12,7 +12,7 @@ const DEFAULT_SHARDS: usize = 16;
 /// A thread-safe implementation of `SieveCache` that uses multiple shards to reduce contention.
 ///
 /// This provides better concurrency than `SyncSieveCache` by splitting the cache into multiple
-/// independent shards, each priotected by its own mutex. Operations on different shards can
+/// independent shards, each protected by its own mutex. Operations on different shards can
 /// proceed in parallel, which can significantly improve throughput in multi-threaded environments.
 ///
 /// # How Sharding Works

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -131,7 +131,10 @@ where
     shards: Vec<Arc<Mutex<SieveCache<K, V, S>>>>,
     /// Number of shards in the cache - kept as a separate field for quick access
     num_shards: usize,
+    /// The hash builder used for sharding keys, cloned into each shard's SieveCache
     hasher: S,
+    // this is stored redundantly here to increase performance of get_shard_index()
+    // by avoiding a lock on the shard to access its hasher
 }
 
 impl<K, V, S> Default for ShardedSieveCache<K, V, S>
@@ -214,11 +217,12 @@ impl<K, V, S> From<crate::SyncSieveCache<K, V, S>> for ShardedSieveCache<K, V, S
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Clone,
 {
     /// Creates a new sharded cache from an existing `SyncSieveCache`.
     ///
     /// This allows for upgrading a standard thread-safe cache to a more scalable sharded version.
+    /// The custom hasher (if any) is preserved from the original cache.
     ///
     /// # Examples
     ///
@@ -232,10 +236,13 @@ where
     /// assert_eq!(sharded_cache.get(&"key".to_string()), Some("value".to_string()));
     /// ```
     fn from(sync_cache: crate::SyncSieveCache<K, V, S>) -> Self {
-        // Create a new sharded cache with the same capacity
+        // Extract the hasher from the inner cache before consuming the sync cache
+        let hasher = sync_cache.hasher();
+
+        // Create a new sharded cache with the same capacity and hasher
         let capacity = sync_cache.capacity();
-        let sharded = Self::new_with_hasher(capacity, Default::default())
-            .expect("Failed to create sharded cache");
+        let sharded =
+            Self::new_with_hasher(capacity, hasher).expect("Failed to create sharded cache");
 
         // Transfer all entries
         for (key, value) in sync_cache.entries() {
@@ -412,6 +419,25 @@ where
             num_shards,
             hasher,
         })
+    }
+
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to another cache variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::ShardedSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: ShardedSieveCache<String, String, _> = ShardedSieveCache::with_shards_and_hasher(100, 4, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// ```
+    pub fn hasher(&self) -> S {
+        self.hasher.clone()
     }
 
     /// Returns the shard index for a given key.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1114,6 +1114,35 @@ mod tests {
     }
 
     #[test]
+    fn test_custom_hasher_sync_sievecache() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let hasher = BuildHasherDefault::<DefaultHasher>::default();
+        let cache: SyncSieveCache<String, String, _> =
+            SyncSieveCache::new_with_hasher(3, hasher).unwrap();
+
+        // Test thread-safe insert and get with custom hasher
+        assert!(cache.insert("key1".to_string(), "value1".to_string()));
+        assert!(cache.insert("key2".to_string(), "value2".to_string()));
+        assert!(cache.insert("key3".to_string(), "value3".to_string()));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get(&"key1".to_string()), Some("value1".to_string()));
+        assert_eq!(cache.get(&"key2".to_string()), Some("value2".to_string()));
+        assert_eq!(cache.get(&"key3".to_string()), Some("value3".to_string()));
+
+        // Test remove with custom hasher
+        cache.remove(&"key1".to_string());
+        assert_eq!(cache.get(&"key1".to_string()), None);
+        assert_eq!(cache.len(), 2);
+
+        // Test contains_key
+        assert!(cache.contains_key(&"key2".to_string()));
+        assert!(!cache.contains_key(&"key1".to_string()));
+    }
+
+    #[test]
     fn test_keys_values_entries() {
         let cache = SyncSieveCache::new(10).unwrap();
         cache.insert("key1".to_string(), "value1".to_string());

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -89,7 +89,7 @@ pub struct SyncSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher
+    S: BuildHasher,
 {
     inner: Arc<Mutex<SieveCache<K, V, S>>>,
 }
@@ -98,7 +98,7 @@ impl<K, V, S> Default for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher + Default
+    S: BuildHasher + Default,
 {
     /// Creates a new cache with a default capacity of 100 entries.
     ///
@@ -116,7 +116,8 @@ where
     /// assert_eq!(cache.capacity(), 100);
     /// ```
     fn default() -> Self {
-        Self::new_with_hasher(100, Default::default()).expect("Failed to create cache with default capacity")
+        Self::new_with_hasher(100, Default::default())
+            .expect("Failed to create cache with default capacity")
     }
 }
 
@@ -124,7 +125,7 @@ impl<K, V, S> fmt::Debug for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync + fmt::Debug,
     V: Send + Sync + fmt::Debug,
-    S: BuildHasher
+    S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let guard = self.locked_cache();
@@ -139,7 +140,7 @@ impl<K, V, S> From<SieveCache<K, V, S>> for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher
+    S: BuildHasher,
 {
     /// Creates a new thread-safe cache from an existing `SieveCache`.
     ///
@@ -167,7 +168,7 @@ impl<K, V, S> IntoIterator for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
-    S: BuildHasher
+    S: BuildHasher,
 {
     type Item = (K, V);
     type IntoIter = std::vec::IntoIter<(K, V)>;
@@ -221,7 +222,7 @@ impl<K, V, S> SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
-    S: BuildHasher
+    S: BuildHasher,
 {
     /// Creates a new thread-safe cache with the given capacity using a custom hash builder.
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::SieveCache;
 use std::borrow::Borrow;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 /// A thread-safe wrapper around `SieveCache`.
@@ -85,18 +85,20 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 /// assert_eq!(cache.get(&"key2".to_string()), Some(12));
 /// ```
 #[derive(Clone)]
-pub struct SyncSieveCache<K, V>
+pub struct SyncSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
+    S: BuildHasher
 {
-    inner: Arc<Mutex<SieveCache<K, V>>>,
+    inner: Arc<Mutex<SieveCache<K, V, S>>>,
 }
 
-impl<K, V> Default for SyncSieveCache<K, V>
+impl<K, V, S> Default for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
+    S: BuildHasher + Default
 {
     /// Creates a new cache with a default capacity of 100 entries.
     ///
@@ -114,14 +116,15 @@ where
     /// assert_eq!(cache.capacity(), 100);
     /// ```
     fn default() -> Self {
-        Self::new(100).expect("Failed to create cache with default capacity")
+        Self::new_with_hasher(100, Default::default()).expect("Failed to create cache with default capacity")
     }
 }
 
-impl<K, V> fmt::Debug for SyncSieveCache<K, V>
+impl<K, V, S> fmt::Debug for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync + fmt::Debug,
     V: Send + Sync + fmt::Debug,
+    S: BuildHasher
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let guard = self.locked_cache();
@@ -132,10 +135,11 @@ where
     }
 }
 
-impl<K, V> From<SieveCache<K, V>> for SyncSieveCache<K, V>
+impl<K, V, S> From<SieveCache<K, V, S>> for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Send + Sync,
+    S: BuildHasher
 {
     /// Creates a new thread-safe cache from an existing `SieveCache`.
     ///
@@ -152,17 +156,18 @@ where
     /// let thread_safe = SyncSieveCache::from(single_threaded);
     /// assert_eq!(thread_safe.get(&"key".to_string()), Some("value".to_string()));
     /// ```
-    fn from(cache: SieveCache<K, V>) -> Self {
+    fn from(cache: SieveCache<K, V, S>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(cache)),
         }
     }
 }
 
-impl<K, V> IntoIterator for SyncSieveCache<K, V>
+impl<K, V, S> IntoIterator for SyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Send + Sync,
     V: Clone + Send + Sync,
+    S: BuildHasher
 {
     type Item = (K, V);
     type IntoIter = std::vec::IntoIter<(K, V)>;
@@ -208,7 +213,38 @@ where
     /// let cache = SyncSieveCache::<String, String>::new(100).unwrap();
     /// ```
     pub fn new(capacity: usize) -> Result<Self, &'static str> {
-        let cache = SieveCache::new(capacity)?;
+        Self::new_with_hasher(capacity, Default::default())
+    }
+}
+
+impl<K, V, S> SyncSieveCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+    V: Send + Sync,
+    S: BuildHasher
+{
+    /// Creates a new thread-safe cache with the given capacity using a custom hash builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The maximum number of entries in the cache
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the capacity is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::SyncSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: SyncSieveCache<String, String, _> = SyncSieveCache::new_with_hasher(100, hasher).unwrap();
+    /// ```
+    pub fn new_with_hasher(capacity: usize, hasher: S) -> Result<Self, &'static str> {
+        let cache = SieveCache::new_with_hasher(capacity, hasher)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(cache)),
         })
@@ -220,7 +256,7 @@ where
     /// If the mutex is poisoned due to a panic in another thread, the poison
     /// error is recovered from by calling `into_inner()` to access the underlying data.
     #[inline]
-    fn locked_cache(&self) -> MutexGuard<'_, SieveCache<K, V>> {
+    fn locked_cache(&self) -> MutexGuard<'_, SieveCache<K, V, S>> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
@@ -738,7 +774,7 @@ where
     /// ```
     pub fn with_lock<F, T>(&self, f: F) -> T
     where
-        F: FnOnce(&mut SieveCache<K, V>) -> T,
+        F: FnOnce(&mut SieveCache<K, V, S>) -> T,
     {
         let mut guard = self.locked_cache();
         f(&mut guard)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -995,6 +995,34 @@ where
     }
 }
 
+// only if the hasher is cloneable, since a reference's lifetime is bound to the MutexGuard
+// which is dropped at the end of the block.
+impl<K, V, S> SyncSieveCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+    V: Send + Sync,
+    S: BuildHasher + Clone,
+{
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to a sharded variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::SyncSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: SyncSieveCache<String, String, _> = SyncSieveCache::new_with_hasher(100, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// ```
+    pub fn hasher(&self) -> S {
+        self.locked_cache().hasher()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/weighted.rs
+++ b/src/weighted.rs
@@ -164,7 +164,7 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher + Clone> WeightedSie
         let inner = SieveCache::new_with_hasher(capacity, hasher.clone())?;
         Ok(Self {
             inner,
-            charged: HashMap::with_hasher(hasher),
+            charged: HashMap::with_capacity_and_hasher(capacity, hasher),
             max_weight,
             current_weight: 0,
         })

--- a/src/weighted.rs
+++ b/src/weighted.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash, RandomState};
 use std::mem;
 
 use crate::SieveCache;
@@ -108,14 +108,20 @@ impl Weigh for &[u8] {
 /// like moka and quick_cache. Users who need accurate tracking after
 /// mutation can `remove` + `insert`.
 ///
+/// # Type Parameters
+///
+/// * `K` - The key type, which must implement `Eq`, `Hash`, `Clone`, and `Weigh`
+/// * `V` - The value type, must implement `Weigh`
+/// * `S` - The hash builder type for the underlying `HashMap` (default: `RandomState`). Must implement `BuildHasher`
+///
 /// # Weight overshoot
 ///
 /// When a single entry's weight exceeds `max_weight`, the eviction loop
 /// empties the cache and then inserts the oversized entry as the sole
 /// occupant. This means `current_weight` can temporarily exceed
 /// `max_weight` by at most the weight of one entry.
-pub struct WeightedSieveCache<K: Eq + Hash + Clone + Weigh, V: Weigh> {
-    inner: SieveCache<K, V>,
+pub struct WeightedSieveCache<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher = RandomState> {
+    inner: SieveCache<K, V, S>,
     /// Per-entry charged weight, snapshotted at insert time. This is the
     /// weight that will be subtracted when the entry is removed or evicted,
     /// regardless of any mutations via `get_mut`.
@@ -133,10 +139,29 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh> WeightedSieveCache<K, V> {
     ///
     /// Returns `Err` if `capacity` is 0 or `max_weight` is 0.
     pub fn new(capacity: usize, max_weight: usize) -> Result<Self, &'static str> {
+        Self::new_with_hasher(capacity, max_weight, Default::default())
+    }
+}
+
+impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher> WeightedSieveCache<K, V, S> {
+    /// Creates a new weighted cache using a custom hash builder.
+    ///
+    /// `capacity` is the maximum number of entries (passed to the inner
+    /// `SieveCache`). `max_weight` is the memory budget in bytes — the
+    /// cache will evict entries to stay at or below this limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The maximum number of entries in the cache
+    /// * `max_weight` - The memory budget in bytes
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// Returns `Err` if `capacity` is 0 or `max_weight` is 0.
+    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
         if max_weight == 0 {
             return Err("max_weight must be greater than zero");
         }
-        let inner = SieveCache::new(capacity)?;
+        let inner = SieveCache::new_with_hasher(capacity, hasher)?;
         Ok(Self {
             inner,
             charged: HashMap::new(),

--- a/src/weighted.rs
+++ b/src/weighted.rs
@@ -120,7 +120,8 @@ impl Weigh for &[u8] {
 /// empties the cache and then inserts the oversized entry as the sole
 /// occupant. This means `current_weight` can temporarily exceed
 /// `max_weight` by at most the weight of one entry.
-pub struct WeightedSieveCache<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher = RandomState> {
+pub struct WeightedSieveCache<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher = RandomState>
+{
     inner: SieveCache<K, V, S>,
     /// Per-entry charged weight, snapshotted at insert time. This is the
     /// weight that will be subtracted when the entry is removed or evicted,
@@ -157,7 +158,11 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher + Clone> WeightedSie
     /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
     ///
     /// Returns `Err` if `capacity` is 0 or `max_weight` is 0.
-    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
+    pub fn new_with_hasher(
+        capacity: usize,
+        max_weight: usize,
+        hasher: S,
+    ) -> Result<Self, &'static str> {
         if max_weight == 0 {
             return Err("max_weight must be greater than zero");
         }

--- a/src/weighted.rs
+++ b/src/weighted.rs
@@ -125,7 +125,7 @@ pub struct WeightedSieveCache<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHa
     /// Per-entry charged weight, snapshotted at insert time. This is the
     /// weight that will be subtracted when the entry is removed or evicted,
     /// regardless of any mutations via `get_mut`.
-    charged: HashMap<K, usize>,
+    charged: HashMap<K, usize, S>,
     max_weight: usize,
     current_weight: usize,
 }
@@ -143,7 +143,7 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh> WeightedSieveCache<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher> WeightedSieveCache<K, V, S> {
+impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher + Clone> WeightedSieveCache<K, V, S> {
     /// Creates a new weighted cache using a custom hash builder.
     ///
     /// `capacity` is the maximum number of entries (passed to the inner
@@ -161,10 +161,10 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher> WeightedSieveCache<
         if max_weight == 0 {
             return Err("max_weight must be greater than zero");
         }
-        let inner = SieveCache::new_with_hasher(capacity, hasher)?;
+        let inner = SieveCache::new_with_hasher(capacity, hasher.clone())?;
         Ok(Self {
             inner,
-            charged: HashMap::new(),
+            charged: HashMap::with_hasher(hasher),
             max_weight,
             current_weight: 0,
         })

--- a/src/weighted.rs
+++ b/src/weighted.rs
@@ -175,6 +175,29 @@ impl<K: Eq + Hash + Clone + Weigh, V: Weigh, S: BuildHasher + Clone> WeightedSie
         })
     }
 
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to another cache variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "doctest")]
+    /// # {
+    /// use sieve_cache::WeightedSieveCache;
+    /// use std::hash::BuildHasherDefault;
+    /// use std::collections::hash_map::DefaultHasher;
+    ///
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: WeightedSieveCache<String, u32, _> = WeightedSieveCache::new_with_hasher(100, 1000, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// # }
+    /// ```
+    pub fn hasher(&self) -> S {
+        self.inner.hasher()
+    }
+
     /// Inserts a key-value pair into the cache.
     ///
     /// If the key already exists, its value is updated and the weight is

--- a/src/weighted_sharded.rs
+++ b/src/weighted_sharded.rs
@@ -30,11 +30,12 @@ pub struct WeightedShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher
+    S: BuildHasher + Clone
 {
     shards: Vec<Arc<Mutex<WeightedSieveCache<K, V, S>>>>,
     num_shards: usize,
     max_weight: usize,
+    hasher: S
 }
 
 impl<K, V> WeightedShardedSieveCache<K, V>
@@ -141,6 +142,7 @@ where
             shards,
             num_shards,
             max_weight,
+            hasher
         })
     }
 
@@ -149,7 +151,7 @@ where
     where
         Q: Hash + ?Sized,
     {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = self.hasher.build_hasher();
         key.hash(&mut hasher);
         let hash = hasher.finish() as usize;
         hash % self.num_shards

--- a/src/weighted_sharded.rs
+++ b/src/weighted_sharded.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::collections::hash_map::DefaultHasher;
 use std::hash::{BuildHasher, Hash, Hasher, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 

--- a/src/weighted_sharded.rs
+++ b/src/weighted_sharded.rs
@@ -29,12 +29,12 @@ pub struct WeightedShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     shards: Vec<Arc<Mutex<WeightedSieveCache<K, V, S>>>>,
     num_shards: usize,
     max_weight: usize,
-    hasher: S
+    hasher: S,
 }
 
 impl<K, V> WeightedShardedSieveCache<K, V>
@@ -65,7 +65,7 @@ impl<K, V, S> WeightedShardedSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     /// Creates a new sharded weighted cache with the default number of shards (16) and a custom hash builder.
     ///
@@ -76,7 +76,11 @@ where
     /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
     ///
     /// Returns `Err` if `capacity` or `max_weight` is 0.
-    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
+    pub fn new_with_hasher(
+        capacity: usize,
+        max_weight: usize,
+        hasher: S,
+    ) -> Result<Self, &'static str> {
         Self::with_shards_and_hasher(capacity, max_weight, DEFAULT_SHARDS, hasher)
     }
 
@@ -96,7 +100,7 @@ where
         capacity: usize,
         max_weight: usize,
         num_shards: usize,
-        hasher: S
+        hasher: S,
     ) -> Result<Self, &'static str> {
         if capacity == 0 {
             return Err("capacity must be greater than 0");
@@ -133,7 +137,8 @@ where
             };
             // base_weight >= 1 is guaranteed by the max_weight >= num_shards check above
 
-            let cache = WeightedSieveCache::new_with_hasher(shard_capacity, shard_weight, hasher.clone())?;
+            let cache =
+                WeightedSieveCache::new_with_hasher(shard_capacity, shard_weight, hasher.clone())?;
             shards.push(Arc::new(Mutex::new(cache)));
         }
 
@@ -141,7 +146,7 @@ where
             shards,
             num_shards,
             max_weight,
-            hasher
+            hasher,
         })
     }
 

--- a/src/weighted_sharded.rs
+++ b/src/weighted_sharded.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use crate::weighted::{Weigh, WeightedSieveCache};
@@ -15,17 +15,24 @@ const DEFAULT_SHARDS: usize = 16;
 /// the remainder given to the first N shards (mirroring the capacity
 /// distribution).
 ///
+/// # Type Parameters
+///
+/// * `K` - The key type, which must implement `Eq`, `Hash`, `Clone`, `Weigh`, `Send`, and `Sync`
+/// * `V` - The value type, must implement `Weigh`, `Send`, and `Sync`
+/// * `S` - The hash builder type for the underlying `HashMap` (default: `RandomState`). Must implement `BuildHasher`
+///
 /// # Weight overshoot
 ///
 /// Because each shard enforces independently, the worst-case total
 /// overshoot is `num_shards * max_single_entry_weight`.
 #[derive(Clone)]
-pub struct WeightedShardedSieveCache<K, V>
+pub struct WeightedShardedSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
+    S: BuildHasher
 {
-    shards: Vec<Arc<Mutex<WeightedSieveCache<K, V>>>>,
+    shards: Vec<Arc<Mutex<WeightedSieveCache<K, V, S>>>>,
     num_shards: usize,
     max_weight: usize,
 }
@@ -49,6 +56,47 @@ where
         capacity: usize,
         max_weight: usize,
         num_shards: usize,
+    ) -> Result<Self, &'static str> {
+        Self::with_shards_and_hasher(capacity, max_weight, num_shards, Default::default())
+    }
+}
+
+impl<K, V, S> WeightedShardedSieveCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Weigh + Send + Sync,
+    V: Weigh + Send + Sync,
+    S: BuildHasher + Clone
+{
+    /// Creates a new sharded weighted cache with the default number of shards (16) and a custom hash builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The total capacity of the cache
+    /// * `max_weight` - The memory budget in bytes
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// Returns `Err` if `capacity` or `max_weight` is 0.
+    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
+        Self::with_shards_and_hasher(capacity, max_weight, DEFAULT_SHARDS, hasher)
+    }
+
+    /// Creates a new sharded weighted cache with a custom number of shards and hash builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The total capacity of the cache
+    /// * `max_weight` - The memory budget in bytes
+    /// * `num_shards` - The number of shards to divide the cache into
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// Returns `Err` if `capacity`, `max_weight`, or `num_shards` is 0,
+    /// or if `max_weight < num_shards` (each shard needs at least 1 byte
+    /// of budget).
+    pub fn with_shards_and_hasher(
+        capacity: usize,
+        max_weight: usize,
+        num_shards: usize,
+        hasher: S
     ) -> Result<Self, &'static str> {
         if capacity == 0 {
             return Err("capacity must be greater than 0");
@@ -85,7 +133,7 @@ where
             };
             // base_weight >= 1 is guaranteed by the max_weight >= num_shards check above
 
-            let cache = WeightedSieveCache::new(shard_capacity, shard_weight)?;
+            let cache = WeightedSieveCache::new_with_hasher(shard_capacity, shard_weight, hasher.clone())?;
             shards.push(Arc::new(Mutex::new(cache)));
         }
 
@@ -108,7 +156,7 @@ where
     }
 
     #[inline]
-    fn locked_shard<Q>(&self, key: &Q) -> MutexGuard<'_, WeightedSieveCache<K, V>>
+    fn locked_shard<Q>(&self, key: &Q) -> MutexGuard<'_, WeightedSieveCache<K, V, S>>
     where
         Q: Hash + ?Sized,
     {

--- a/src/weighted_sharded.rs
+++ b/src/weighted_sharded.rs
@@ -34,6 +34,9 @@ where
     shards: Vec<Arc<Mutex<WeightedSieveCache<K, V, S>>>>,
     num_shards: usize,
     max_weight: usize,
+
+    // We store the hasher here to increase the performance of methods accessing the hasher,
+    // by avoiding the need to lock a shard just to access the hasher.
     hasher: S,
 }
 
@@ -148,6 +151,25 @@ where
             max_weight,
             hasher,
         })
+    }
+
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to another cache variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::WeightedShardedSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: WeightedShardedSieveCache<String, u32, _> = WeightedShardedSieveCache::with_shards_and_hasher(100, 1000, 4, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// ```
+    pub fn hasher(&self) -> S {
+        self.hasher.clone()
     }
 
     #[inline]

--- a/src/weighted_sync.rs
+++ b/src/weighted_sync.rs
@@ -24,7 +24,7 @@ pub struct WeightedSyncSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher
+    S: BuildHasher,
 {
     inner: Arc<Mutex<WeightedSieveCache<K, V, S>>>,
 }
@@ -46,7 +46,7 @@ impl<K, V, S> WeightedSyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher + Clone
+    S: BuildHasher + Clone,
 {
     /// Creates a new thread-safe weighted cache with a custom hash builder.
     ///
@@ -57,7 +57,11 @@ where
     /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
     ///
     /// Returns `Err` if `capacity` or `max_weight` is 0.
-    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
+    pub fn new_with_hasher(
+        capacity: usize,
+        max_weight: usize,
+        hasher: S,
+    ) -> Result<Self, &'static str> {
         let cache = WeightedSieveCache::new_with_hasher(capacity, max_weight, hasher)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(cache)),

--- a/src/weighted_sync.rs
+++ b/src/weighted_sync.rs
@@ -46,7 +46,7 @@ impl<K, V, S> WeightedSyncSieveCache<K, V, S>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
-    S: BuildHasher
+    S: BuildHasher + Clone
 {
     /// Creates a new thread-safe weighted cache with a custom hash builder.
     ///

--- a/src/weighted_sync.rs
+++ b/src/weighted_sync.rs
@@ -1,5 +1,5 @@
 use std::borrow::Borrow;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use crate::weighted::{Weigh, WeightedSieveCache};
@@ -11,15 +11,22 @@ use crate::weighted::{Weigh, WeightedSieveCache};
 /// thread safety. The weight bookkeeping lives inside the mutex alongside
 /// the cache data so that every mutation is atomic with respect to weight.
 ///
+/// # Type Parameters
+///
+/// * `K` - The key type, which must implement `Eq`, `Hash`, `Clone`, `Weigh`, `Send`, and `Sync`
+/// * `V` - The value type, must implement `Weigh`, `Send`, and `Sync`
+/// * `S` - The hash builder type for the underlying `HashMap` (default: `RandomState`). Must implement `BuildHasher`
+///
 /// For higher concurrency, see
 /// [`WeightedShardedSieveCache`](crate::WeightedShardedSieveCache).
 #[derive(Clone)]
-pub struct WeightedSyncSieveCache<K, V>
+pub struct WeightedSyncSieveCache<K, V, S = RandomState>
 where
     K: Eq + Hash + Clone + Weigh + Send + Sync,
     V: Weigh + Send + Sync,
+    S: BuildHasher
 {
-    inner: Arc<Mutex<WeightedSieveCache<K, V>>>,
+    inner: Arc<Mutex<WeightedSieveCache<K, V, S>>>,
 }
 
 impl<K, V> WeightedSyncSieveCache<K, V>
@@ -31,14 +38,34 @@ where
     ///
     /// Returns `Err` if `capacity` or `max_weight` is 0.
     pub fn new(capacity: usize, max_weight: usize) -> Result<Self, &'static str> {
-        let cache = WeightedSieveCache::new(capacity, max_weight)?;
+        Self::new_with_hasher(capacity, max_weight, Default::default())
+    }
+}
+
+impl<K, V, S> WeightedSyncSieveCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Weigh + Send + Sync,
+    V: Weigh + Send + Sync,
+    S: BuildHasher
+{
+    /// Creates a new thread-safe weighted cache with a custom hash builder.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - The maximum number of entries in the cache
+    /// * `max_weight` - The memory budget in bytes
+    /// * `hasher` - A hash builder instance (e.g., from `ahash::AHasher` or `std::collections::hash_map::RandomState`)
+    ///
+    /// Returns `Err` if `capacity` or `max_weight` is 0.
+    pub fn new_with_hasher(capacity: usize, max_weight: usize, hasher: S) -> Result<Self, &'static str> {
+        let cache = WeightedSieveCache::new_with_hasher(capacity, max_weight, hasher)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(cache)),
         })
     }
 
     #[inline]
-    fn locked_cache(&self) -> MutexGuard<'_, WeightedSieveCache<K, V>> {
+    fn locked_cache(&self) -> MutexGuard<'_, WeightedSieveCache<K, V, S>> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
@@ -178,7 +205,7 @@ where
     /// Gets exclusive access to the underlying weighted cache.
     pub fn with_lock<F, T>(&self, f: F) -> T
     where
-        F: FnOnce(&mut WeightedSieveCache<K, V>) -> T,
+        F: FnOnce(&mut WeightedSieveCache<K, V, S>) -> T,
     {
         let mut guard = self.locked_cache();
         f(&mut guard)

--- a/src/weighted_sync.rs
+++ b/src/weighted_sync.rs
@@ -68,6 +68,25 @@ where
         })
     }
 
+    /// Returns a clone of the hash builder used by this cache.
+    ///
+    /// This is useful when converting to another cache variant and you want
+    /// to preserve the custom hasher configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sieve_cache::WeightedSyncSieveCache;
+    /// # use std::hash::BuildHasherDefault;
+    /// # use std::collections::hash_map::DefaultHasher;
+    /// let hasher = BuildHasherDefault::<DefaultHasher>::default();
+    /// let cache: WeightedSyncSieveCache<String, u32, _> = WeightedSyncSieveCache::new_with_hasher(100, 1000, hasher).unwrap();
+    /// let retrieved_hasher = cache.hasher();
+    /// ```
+    pub fn hasher(&self) -> S {
+        self.locked_cache().hasher()
+    }
+
     #[inline]
     fn locked_cache(&self) -> MutexGuard<'_, WeightedSieveCache<K, V, S>> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -1,5 +1,9 @@
 mod custom_hasher_test {
-    use std::{cell::RefCell, hash::{BuildHasher, Hasher}, rc::Rc};
+    use std::{
+        cell::RefCell,
+        hash::{BuildHasher, Hasher},
+        rc::Rc,
+    };
 
     use sieve_cache::{SieveCache, SyncSieveCache};
 
@@ -11,7 +15,10 @@ mod custom_hasher_test {
 
     impl CustomHasher {
         fn new() -> Self {
-            CustomHasher { hash: 0, invocations: Rc::new(RefCell::new(0)) }
+            CustomHasher {
+                hash: 0,
+                invocations: Rc::new(RefCell::new(0)),
+            }
         }
     }
 
@@ -22,8 +29,8 @@ mod custom_hasher_test {
 
         fn write(&mut self, bytes: &[u8]) {
             //convert the byte array to a u64. Just for testing.
-            //for u8, this is a single byte. 
-            //The tests below should use a u8 key, as introducing keys longer than a single byte 
+            //for u8, this is a single byte.
+            //The tests below should use a u8 key, as introducing keys longer than a single byte
             //would cause issues with endianness and could lead to evictions.
             for b in bytes {
                 self.hash = self.hash << 8 | (*b as u64);
@@ -37,14 +44,18 @@ mod custom_hasher_test {
         type Hasher = Self;
 
         fn build_hasher(&self) -> Self::Hasher {
-            CustomHasher { hash: 0, invocations: Rc::clone(&self.invocations) }
+            CustomHasher {
+                hash: 0,
+                invocations: Rc::clone(&self.invocations),
+            }
         }
     }
 
     #[test]
     fn test_custom_hasher() {
         let hasher = CustomHasher::new();
-        let mut cache = SieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
+        let mut cache =
+            SieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -60,7 +71,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);
@@ -70,7 +81,8 @@ mod custom_hasher_test {
     #[test]
     fn test_custom_hasher_sync() {
         let hasher = CustomHasher::new();
-        let cache = SyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
+        let cache =
+            SyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -86,7 +98,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);
@@ -96,7 +108,11 @@ mod custom_hasher_test {
     #[test]
     fn test_custom_hasher_sharded() {
         let hasher = CustomHasher::new();
-        let cache = sieve_cache::ShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(100, hasher.clone()).unwrap();
+        let cache = sieve_cache::ShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(
+            100,
+            hasher.clone(),
+        )
+        .unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -112,7 +128,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);
@@ -122,7 +138,12 @@ mod custom_hasher_test {
     #[test]
     fn test_custom_hasher_weighted() {
         let hasher = CustomHasher::new();
-        let mut cache = sieve_cache::WeightedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
+        let mut cache = sieve_cache::WeightedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(
+            10,
+            100,
+            hasher.clone(),
+        )
+        .unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -138,7 +159,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);
@@ -148,7 +169,12 @@ mod custom_hasher_test {
     #[test]
     fn test_custom_hasher_weighted_sync() {
         let hasher = CustomHasher::new();
-        let cache = sieve_cache::WeightedSyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
+        let cache = sieve_cache::WeightedSyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(
+            10,
+            100,
+            hasher.clone(),
+        )
+        .unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -164,7 +190,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);
@@ -174,7 +200,13 @@ mod custom_hasher_test {
     #[test]
     fn test_custom_hasher_weighted_sharded() {
         let hasher = CustomHasher::new();
-        let cache = sieve_cache::WeightedShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
+        let cache =
+            sieve_cache::WeightedShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(
+                10,
+                100,
+                hasher.clone(),
+            )
+            .unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -190,7 +222,7 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
 
-        //at least one invocation per get and remove, plus some for the insertions. 
+        //at least one invocation per get and remove, plus some for the insertions.
         //The exact number depends on the implementation details of the sharding and eviction logic,
         //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
         assert!(*hasher.invocations.borrow() >= 9);

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -1,6 +1,5 @@
 mod custom_hasher_test {
-    use core::hash;
-    use std::{cell::RefCell, hash::{BuildHasher, Hash, Hasher}, rc::Rc, sync::Arc};
+    use std::{cell::RefCell, hash::{BuildHasher, Hasher}, rc::Rc};
 
     use sieve_cache::{SieveCache, SyncSieveCache};
 

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -1,0 +1,151 @@
+mod custom_hasher_test {
+    use std::hash::{BuildHasher, Hasher};
+
+    use sieve_cache::{SieveCache, SyncSieveCache};
+
+
+    struct CustomHasher {
+        hash: u64,
+    }
+
+    impl Hasher for CustomHasher {
+        fn finish(&self) -> u64 {
+            // Implement a custom hash function here
+            0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            for b in bytes {
+                self.hash = self.hash << 8 | (*b as u64);
+            }
+        }
+    }
+
+    impl BuildHasher for CustomHasher {
+        type Hasher = Self;
+
+        fn build_hasher(&self) -> Self::Hasher {
+            CustomHasher { hash: 0}
+        }
+    }
+
+    impl Clone for CustomHasher {
+        fn clone(&self) -> Self {
+            CustomHasher { hash: self.hash }
+        }
+    }
+
+    #[test]
+    fn test_custom_hasher() {
+        let mut cache = SieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(&100u64));
+        assert_eq!(cache.get(&2), Some(&200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_hasher_sync() {
+        let cache = SyncSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(100u64));
+        assert_eq!(cache.get(&2), Some(200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_hasher_sharded() {
+        let cache = sieve_cache::ShardedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(100, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(100u64));
+        assert_eq!(cache.get(&2), Some(200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_hasher_weighted() {
+        let mut cache = sieve_cache::WeightedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(&100u64));
+        assert_eq!(cache.get(&2), Some(&200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_hasher_weighted_sync() {
+        let cache = sieve_cache::WeightedSyncSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(100u64));
+        assert_eq!(cache.get(&2), Some(200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_hasher_weighted_sharded() {
+        let cache = sieve_cache::WeightedShardedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        cache.insert(1, 100);
+        cache.insert(2, 200);
+
+        assert_eq!(cache.get(&1), Some(100u64));
+        assert_eq!(cache.get(&2), Some(200u64));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&3), None);
+
+        cache.remove(&1);
+        cache.remove(&2);
+
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), None);
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -5,7 +5,9 @@ mod custom_hasher_test {
         rc::Rc,
     };
 
-    use sieve_cache::{SieveCache, SyncSieveCache};
+    use sieve_cache::SieveCache;
+    #[cfg(feature = "sync")] 
+    use sieve_cache::SyncSieveCache;
 
     #[derive(Clone)]
     struct CustomHasher {

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -1,23 +1,36 @@
 mod custom_hasher_test {
-    use std::hash::{BuildHasher, Hasher};
+    use core::hash;
+    use std::{cell::RefCell, hash::{BuildHasher, Hash, Hasher}, rc::Rc, sync::Arc};
 
     use sieve_cache::{SieveCache, SyncSieveCache};
 
-
+    #[derive(Clone)]
     struct CustomHasher {
         hash: u64,
+        invocations: Rc<RefCell<usize>>,
+    }
+
+    impl CustomHasher {
+        fn new() -> Self {
+            CustomHasher { hash: 0, invocations: Rc::new(RefCell::new(0)) }
+        }
     }
 
     impl Hasher for CustomHasher {
         fn finish(&self) -> u64 {
-            // Implement a custom hash function here
-            0
+            self.hash
         }
 
         fn write(&mut self, bytes: &[u8]) {
+            //convert the byte array to a u64. Just for testing.
+            //for u8, this is a single byte. 
+            //The tests below should use a u8 key, as introducing keys longer than a single byte 
+            //would cause issues with endianness and could lead to evictions.
             for b in bytes {
                 self.hash = self.hash << 8 | (*b as u64);
             }
+
+            *self.invocations.borrow_mut() += 1;
         }
     }
 
@@ -25,19 +38,14 @@ mod custom_hasher_test {
         type Hasher = Self;
 
         fn build_hasher(&self) -> Self::Hasher {
-            CustomHasher { hash: 0}
-        }
-    }
-
-    impl Clone for CustomHasher {
-        fn clone(&self) -> Self {
-            CustomHasher { hash: self.hash }
+            CustomHasher { hash: 0, invocations: Rc::clone(&self.invocations) }
         }
     }
 
     #[test]
     fn test_custom_hasher() {
-        let mut cache = SieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let mut cache = SieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -52,11 +60,18 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 
+    #[cfg(feature = "sync")]
     #[test]
     fn test_custom_hasher_sync() {
-        let cache = SyncSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let cache = SyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -71,11 +86,18 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 
+    #[cfg(feature = "sharded")]
     #[test]
     fn test_custom_hasher_sharded() {
-        let cache = sieve_cache::ShardedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(100, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let cache = sieve_cache::ShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(100, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -90,11 +112,18 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 
+    #[cfg(feature = "weighted")]
     #[test]
     fn test_custom_hasher_weighted() {
-        let mut cache = sieve_cache::WeightedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let mut cache = sieve_cache::WeightedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -109,11 +138,18 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 
+    #[cfg(all(feature = "weighted", feature = "sync"))]
     #[test]
     fn test_custom_hasher_weighted_sync() {
-        let cache = sieve_cache::WeightedSyncSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let cache = sieve_cache::WeightedSyncSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -128,11 +164,18 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 
+    #[cfg(all(feature = "weighted", feature = "sharded"))]
     #[test]
     fn test_custom_hasher_weighted_sharded() {
-        let cache = sieve_cache::WeightedShardedSieveCache::<u64, u64, CustomHasher>::new_with_hasher(10, 100, CustomHasher { hash: 0 }).unwrap();
+        let hasher = CustomHasher::new();
+        let cache = sieve_cache::WeightedShardedSieveCache::<u8, u64, CustomHasher>::new_with_hasher(10, 100, hasher.clone()).unwrap();
         cache.insert(1, 100);
         cache.insert(2, 200);
 
@@ -147,5 +190,10 @@ mod custom_hasher_test {
         assert_eq!(cache.get(&1), None);
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.len(), 0);
+
+        //at least one invocation per get and remove, plus some for the insertions. 
+        //The exact number depends on the implementation details of the sharding and eviction logic,
+        //as well as the hashing logic used in the standard library, which may call the hasher multiple times for certain operations.
+        assert!(*hasher.invocations.borrow() >= 9);
     }
 }

--- a/tests/custom_hasher_test.rs
+++ b/tests/custom_hasher_test.rs
@@ -6,7 +6,7 @@ mod custom_hasher_test {
     };
 
     use sieve_cache::SieveCache;
-    #[cfg(feature = "sync")] 
+    #[cfg(feature = "sync")]
     use sieve_cache::SyncSieveCache;
 
     #[derive(Clone)]

--- a/tests/weighted_test.rs
+++ b/tests/weighted_test.rs
@@ -383,6 +383,38 @@ mod weighted_tests {
         assert!(evicted.is_some());
         assert_eq!(cache.current_weight(), 0);
     }
+
+    #[test]
+    fn custom_hasher_weighted_sievecache() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let hasher = BuildHasherDefault::<DefaultHasher>::default();
+        let mut cache: WeightedSieveCache<String, String, _> =
+            WeightedSieveCache::new_with_hasher(5, 1000, hasher).unwrap();
+
+        // Test insert and get with custom hasher
+        assert!(cache.insert("key1".to_string(), "value1".to_string()));
+        assert!(cache.insert("key2".to_string(), "value2".to_string()));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(cache.get("key2"), Some(&"value2".to_string()));
+
+        // Test weight tracking with custom hasher
+        let initial_weight = cache.current_weight();
+        assert!(initial_weight > 0);
+
+        // Test remove and weight decrease
+        cache.remove("key1");
+        assert_eq!(cache.get("key1"), None);
+        let weight_after_remove = cache.current_weight();
+        assert!(weight_after_remove < initial_weight);
+
+        // Test contains_key
+        assert!(cache.contains_key("key2"));
+        assert!(!cache.contains_key("key1"));
+    }
 }
 
 #[cfg(all(feature = "weighted", feature = "sync"))]
@@ -462,6 +494,35 @@ mod weighted_sync_tests {
         let r: Result<WeightedSyncSieveCache<String, String>, _> =
             WeightedSyncSieveCache::new(10, 0);
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn custom_hasher_weighted_sync_sievecache() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let hasher = BuildHasherDefault::<DefaultHasher>::default();
+        let cache: WeightedSyncSieveCache<String, String, _> =
+            WeightedSyncSieveCache::new_with_hasher(5, 1000, hasher).unwrap();
+
+        // Test thread-safe insert and get with custom hasher
+        assert!(cache.insert("key1".to_string(), "value1".to_string()));
+        assert!(cache.insert("key2".to_string(), "value2".to_string()));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get(&"key1".to_string()), Some("value1".to_string()));
+        assert_eq!(cache.get(&"key2".to_string()), Some("value2".to_string()));
+
+        // Test weight tracking with custom hasher
+        assert!(cache.current_weight() > 0);
+
+        // Test remove
+        cache.remove(&"key1".to_string());
+        assert_eq!(cache.get(&"key1".to_string()), None);
+
+        // Test contains_key
+        assert!(cache.contains_key(&"key2".to_string()));
+        assert!(!cache.contains_key(&"key1".to_string()));
     }
 }
 
@@ -606,5 +667,64 @@ mod weighted_sharded_tests {
         assert!(pair.is_some());
         let (k, _) = pair.unwrap();
         assert!(!cache.contains_key(&k));
+    }
+
+    #[test]
+    fn custom_hasher_weighted_sharded_sievecache() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let cache: WeightedShardedSieveCache<String, i32, _> =
+            WeightedShardedSieveCache::new_with_hasher(10, 1000, BuildHasherDefault::<DefaultHasher>::new()).unwrap();
+
+        // Test insert and get with custom hasher
+        assert!(cache.insert("a".to_string(), 1));
+        assert!(cache.insert("b".to_string(), 2));
+        assert!(cache.insert("c".to_string(), 3));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get(&"a".to_string()), Some(1));
+        assert_eq!(cache.get(&"b".to_string()), Some(2));
+        assert_eq!(cache.get(&"c".to_string()), Some(3));
+
+        // Test weight tracking
+        assert!(cache.current_weight() > 0);
+
+        // Test remove
+        assert_eq!(cache.remove(&"a".to_string()), Some(1));
+        assert_eq!(cache.get(&"a".to_string()), None);
+
+        // Test contains_key
+        assert!(cache.contains_key(&"b".to_string()));
+        assert!(!cache.contains_key(&"a".to_string()));
+    }
+
+    #[test]
+    fn custom_hasher_weighted_sharded_sievecache_with_shards() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::BuildHasherDefault;
+
+        let hasher = BuildHasherDefault::<DefaultHasher>::default();
+        let cache: WeightedShardedSieveCache<String, String, _> =
+            WeightedShardedSieveCache::with_shards_and_hasher(10, 1000, 4, hasher).unwrap();
+
+        // Test insert and get with custom hasher and custom shard count
+        assert!(cache.insert("key1".to_string(), "value1".to_string()));
+        assert!(cache.insert("key2".to_string(), "value2".to_string()));
+        assert!(cache.insert("key3".to_string(), "value3".to_string()));
+        assert!(cache.insert("key4".to_string(), "value4".to_string()));
+
+        // Verify values are retrievable
+        assert_eq!(cache.get(&"key1".to_string()), Some("value1".to_string()));
+        assert_eq!(cache.get(&"key2".to_string()), Some("value2".to_string()));
+        assert_eq!(cache.get(&"key3".to_string()), Some("value3".to_string()));
+        assert_eq!(cache.get(&"key4".to_string()), Some("value4".to_string()));
+
+        // Test weight and operations
+        assert!(cache.current_weight() > 0);
+
+        assert_eq!(cache.remove(&"key2".to_string()), Some("value2".to_string()));
+        assert!(!cache.contains_key(&"key2".to_string()));
+        assert_eq!(cache.len(), 3);
     }
 }

--- a/tests/weighted_test.rs
+++ b/tests/weighted_test.rs
@@ -675,7 +675,12 @@ mod weighted_sharded_tests {
         use std::hash::BuildHasherDefault;
 
         let cache: WeightedShardedSieveCache<String, i32, _> =
-            WeightedShardedSieveCache::new_with_hasher(10, 1000, BuildHasherDefault::<DefaultHasher>::new()).unwrap();
+            WeightedShardedSieveCache::new_with_hasher(
+                10,
+                1000,
+                BuildHasherDefault::<DefaultHasher>::new(),
+            )
+            .unwrap();
 
         // Test insert and get with custom hasher
         assert!(cache.insert("a".to_string(), 1));
@@ -723,7 +728,10 @@ mod weighted_sharded_tests {
         // Test weight and operations
         assert!(cache.current_weight() > 0);
 
-        assert_eq!(cache.remove(&"key2".to_string()), Some("value2".to_string()));
+        assert_eq!(
+            cache.remove(&"key2".to_string()),
+            Some("value2".to_string())
+        );
         assert!(!cache.contains_key(&"key2".to_string()));
         assert_eq!(cache.len(), 3);
     }


### PR DESCRIPTION
# Add custom hash builder support (`new_with_hasher`)

Adds a generic type parameter `S: BuildHasher` (defaulting to `RandomState`) to all cache types.
Each type now exposes a `new_with_hasher(...)` constructor (and `with_shards_and_hasher` for sharded variants), allowing callers to plug in a custom hashing algorithm such as `ahash` for improved performance. The existing `new(...)` constructors are unchanged and delegate to the new ones using `Default::default()`, so there are no breaking changes.

Documentation and README updated with usage examples.